### PR TITLE
Removed unnecessary reference to spring-cloud-stream 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <!-- Spring Boot / Cloud / Stream deps -->
     <spring.boot.version>2.0.0.M7</spring.boot.version>
     <spring.cloud.version>Finchley.M5</spring.cloud.version>
-    <spring.cloud.stream.version>Elmhurst.M3</spring.cloud.stream.version>
 
     <h2.version>1.4.193</h2.version>
 
@@ -419,13 +418,6 @@
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
         <version>${spring.cloud.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-stream-dependencies</artifactId>
-        <version>${spring.cloud.stream.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
- removed unnecessary reference to spring-cloud-stream from dependency management since the version is already managed by spring-cloud BOM

refs [#1700](https://github.com/Activiti/Activiti/issues/1700)