### PR TITLE
Fix REST docs

### DIFF
--- a/activiti-cloud-parent/pom.xml
+++ b/activiti-cloud-parent/pom.xml
@@ -52,7 +52,7 @@
           <executions>
             <execution>
               <id>generate-docs</id>
-              <phase>prepare-package</phase>
+              <phase>post-integration-test</phase>
               <goals>
                 <goal>process-asciidoc</goal>
               </goals>


### PR DESCRIPTION
Move `asciidoctor-maven-plugin` to `post-integration-test` phase to make sure that snippets were generated before