### PR TITLE
fix service-level integration tests

### DIFF
--- a/activiti-cloud-parent/pom.xml
+++ b/activiti-cloud-parent/pom.xml
@@ -68,30 +68,6 @@
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
           <version>${docker-maven-plugin.version}</version>
-          <configuration>
-            <images>
-              <image>
-                <name>activiti/${project.artifactId}</name>
-                <alias>${project.artifactId}</alias>
-                <build>
-                  <from>openjdk:alpine</from>
-                  <assembly>
-                    <descriptorRef>artifact</descriptorRef>
-                  </assembly>
-                  <cmd>java ${JAVA_OPTS} -jar maven/${project.artifactId}-${project.version}.jar</cmd>
-                </build>
-              </image>
-            </images>
-          </configuration>
-          <executions>
-            <execution>
-              <id>docker:build</id>
-              <phase>install</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
Integration tests failing as they use docker-maven-plugin to start other containers (e.g. sso-idm) and with the present configuration they overwrite those images instead.

The PRs also include changes to add the activiti snapshots repo in the examples level so that those projects can build again as they're also failing since they're not able to see the parent snapshot.

Linked PRs:

https://github.com/Activiti/activiti-build/pull/22
https://github.com/Activiti/activiti-cloud-query/pull/25
https://github.com/Activiti/example-runtime-bundle/pull/8
https://github.com/Activiti/activiti-cloud-audit/pull/23
https://github.com/Activiti/activiti-cloud-audit-mongodb/pull/10
https://github.com/Activiti/activiti-cloud-registry/pull/10
https://github.com/Alfresco/alfresco-api-gateway/pull/23
https://github.com/Activiti/activiti-cloud-modeling-backend/pull/6