### PR TITLE
require -Pdocker flag to do docker build

### DIFF
--- a/activiti-cloud-uservices-parent/pom.xml
+++ b/activiti-cloud-uservices-parent/pom.xml
@@ -31,11 +31,6 @@
   <profiles>
     <profile>
       <id>docker</id>
-      <activation>
-        <file>
-          <exists>Dockerfile</exists>
-        </file>
-      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Without this change the docker image build would happen by default so long as there's a Dockerfile present in the repo. This has been useful for building images locally, in combination with https://github.com/Activiti/activiti-scripts

But in JX the docker image is built with skaffold and there's a mvn clean deploy step in the pipeline by default, which in some clusters we've seen fail because it can't find the openjdk:alpine image in the cluster's docker registry. We could disable it in the Jenkinsfile but if we disable it by default then we avoid needing to make that change in the Jenkinsfile. It can still be activated using -Pdocker.