### PR TITLE
fix: Revert changes for activiti-build parent and activiti-core-dependencies propagation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,12 @@
   <modules>
     <module>activiti-cloud-dependencies-parent</module>
   </modules>
+  <repositories>
+    <repository>
+      <id>activiti-releases</id>
+      <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>
+    </repository>
+  </repositories>  
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -2,37 +2,117 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.activiti.build</groupId>
-    <artifactId>activiti-parent</artifactId>
-    <version>7.1.181</version>
-  </parent>
   <groupId>org.activiti.cloud.build</groupId>
   <artifactId>activiti-cloud-parent</artifactId>
   <version>7.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Activiti Cloud :: Build</name>
+  <description>${project.name}</description>
+  <url>http://activiti.org</url>
   <inceptionYear>2017</inceptionYear>
+  <organization>
+    <name>Alfresco</name>
+    <url>http://www.alfresco.com</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>Apache v2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+    </license>
+  </licenses>
+  <developers>
+  </developers>
+  <scm>
+    <url>http://github.com/Activiti/${project.artifactId}</url>
+    <connection>scm:git:git://github.com/Activiti/${project.artifactId}.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/Activiti/${project.artifactId}.git</developerConnection>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/Activiti/Activiti/issues</url>
+  </issueManagement>
+  <ciManagement>
+    <system>Travis</system>
+    <url>https://travis-ci.org/Activiti/${project.artifactId}</url>
+  </ciManagement>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <java.version>8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+
+    <!-- configuration properties for tests-->
+    <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>
+    <generated-assertions-package>org.activiti.test</generated-assertions-package>
+    <!-- Docker props -->
+    <docker.keycloak.port>8180</docker.keycloak.port>
+    <docker.keycloak.start.timeout>40000</docker.keycloak.start.timeout>
+    <docker.rabbitmq.tcp.port>5672</docker.rabbitmq.tcp.port>
+    <docker.rabbitmq.cli.port>15672</docker.rabbitmq.cli.port>
+    <docker.rabbitmq.start.timeout>15000</docker.rabbitmq.start.timeout>
+    <!-- configurations for Spring REST docs -->
+    <asciidoc.filename>index.adoc</asciidoc.filename>
+    <!-- plugin versions -->
+    <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
+    <assertj-assertions-generator-maven-plugin.version>2.0.0</assertj-assertions-generator-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+    <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
+    <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
+    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+    <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
+    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+  </properties>
   <modules>
     <module>activiti-cloud-dependencies-parent</module>
   </modules>
-  <properties>
-    <project.scm.repository>activiti-cloud-build</project.scm.repository>
-    <!-- versions -->
-    <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
-    <asciidoctor-maven-plugin.version>1.6.0</asciidoctor-maven-plugin.version>
-    <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
-    <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
-  </properties>
-  <repositories>
-    <repository>
-      <id>activiti-releases</id>
-      <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>
-    </repository>
-  </repositories>
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${maven-release-plugin.version}</version>
+          <configuration>
+            <releaseProfiles>sign</releaseProfiles>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <tagNameFormat>activiti-@{project.version}</tagNameFormat>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <failIfNoTests>false</failIfNoTests>
+            <trimStackTrace>false</trimStackTrace>
+            <excludes>
+              <exclude>**/*TestCase.java</exclude>
+              <exclude>**/*IT.java</exclude>
+            </excludes>
+            <runOrder>alphabetical</runOrder>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+        </plugin>
         <plugin>
           <groupId>com.mysema.maven</groupId>
           <artifactId>apt-maven-plugin</artifactId>
@@ -62,7 +142,7 @@
                 <goal>process-asciidoc</goal>
               </goals>
               <configuration>
-                <sourceDocumentName>index.adoc</sourceDocumentName>
+                <sourceDocumentName>${asciidoc.filename}</sourceDocumentName>
                 <backend>html</backend>
                 <doctype>book</doctype>
                 <attributes>
@@ -71,6 +151,39 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>${maven-source-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven-install-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven-javadoc-plugin.version}</version>
+          <configuration>
+            <doclint>none</doclint>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>
@@ -90,11 +203,246 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>io.fabric8</groupId>
-          <artifactId>docker-maven-plugin</artifactId>
-          <version>${docker-maven-plugin.version}</version>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-generated-assertions-folder</id>
+              <phase>generate-test-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${generated-assertions-folder}</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+          <version>${assertj-assertions-generator-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <release>${java.version}</release>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <optimize>true</optimize>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <!-- Unit tests configuration-->
+          <execution>
+            <id>pre-unit-test</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <!-- Integration tests configuration-->
+          <execution>
+            <id>pre-integration-test</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-integration-test</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>report-integration</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>attach-sources</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- Profile to sign artifacts, triggered when releasing -->
+    <profile>
+      <id>sign</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven-gpg-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <distributionManagement>
+        <repository>
+          <id>central-releases-staging</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+    <!-- Activate integration tests -->
+    <profile>
+      <id>integration-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>skipITs</name>
+          <value>false</value>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>io.fabric8</groupId>
+              <artifactId>docker-maven-plugin</artifactId>
+              <version>${docker-maven-plugin.version}</version>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- profile to make eclipse happy -->
+    <profile>
+      <id>m2eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <versionRange>[${exec-maven-plugin.version},)</versionRange>
+                        <goals>
+                          <goal>java</goal>
+                          <goal>exec</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute>
+                          <runOnIncremental>true</runOnIncremental>
+                          <runOnConfiguration>true</runOnConfiguration>
+                        </execute>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.assertj</groupId>
+                        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+                        <versionRange>[${assertj-assertions-generator-maven-plugin.version},)</versionRange>
+                        <goals>
+                          <goal>generate-assertions</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <execute>
+                          <runOnIncremental>true</runOnIncremental>
+                          <runOnConfiguration>true</runOnConfiguration>
+                        </execute>
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <deployAtEnd>true</deployAtEnd>
+        </configuration>
+      </plugin>      
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -149,9 +149,9 @@
     </developer>
   </developers>
   <scm>
-    <url>http://github.com/Activiti/${project.artifactId}</url>
-    <connection>scm:git:git://github.com/Activiti/${project.artifactId}.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/Activiti/${project.artifactId}.git</developerConnection>
+    <url>http://github.com/Activiti/${project.scm.repository}</url>
+    <connection>scm:git:git://github.com/Activiti/${project.scm.repository}.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/Activiti/${project.scm.repository}.git</developerConnection>
   </scm>
   <issueManagement>
     <system>GitHub</system>
@@ -159,25 +159,22 @@
   </issueManagement>
   <ciManagement>
     <system>Travis</system>
-    <url>https://travis-ci.org/Activiti/${project.artifactId}</url>
+    <url>https://travis-ci.com/Activiti/${project.artifactId}</url>
   </ciManagement>
   <properties>
+    <project.scm.repository>activiti-cloud-build</project.scm.repository>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <java.version>8</java.version>
+    <java.release>8</java.release>
+    <java.version>1.${java.release}</java.version>
+    <maven.compiler.release>${java.release}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- configuration properties for tests-->
     <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>
     <generated-assertions-package>org.activiti.test</generated-assertions-package>
-    <!-- Docker props -->
-    <docker.keycloak.port>8180</docker.keycloak.port>
-    <docker.keycloak.start.timeout>40000</docker.keycloak.start.timeout>
-    <docker.rabbitmq.tcp.port>5672</docker.rabbitmq.tcp.port>
-    <docker.rabbitmq.cli.port>15672</docker.rabbitmq.cli.port>
-    <docker.rabbitmq.start.timeout>15000</docker.rabbitmq.start.timeout>
     <!-- configurations for Spring REST docs -->
     <asciidoc.filename>index.adoc</asciidoc.filename>
     <!-- plugin versions -->
@@ -210,7 +207,7 @@
       <id>activiti-releases</id>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>
     </repository>
-  </repositories>  
+  </repositories>
   <build>
     <pluginManagement>
       <plugins>
@@ -274,7 +271,7 @@
                 <goal>process-asciidoc</goal>
               </goals>
               <configuration>
-                <sourceDocumentName>${asciidoc.filename}</sourceDocumentName>
+                <sourceDocumentName>index.adoc</sourceDocumentName>
                 <backend>html</backend>
                 <doctype>book</doctype>
                 <attributes>
@@ -376,7 +373,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <release>${java.version}</release>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <optimize>true</optimize>
@@ -424,7 +420,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
         <configuration>
           <deployAtEnd>true</deployAtEnd>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
   </issueManagement>
   <ciManagement>
     <system>Travis</system>
-    <url>https://travis-ci.com/Activiti/${project.artifactId}</url>
+    <url>https://travis-ci.com/Activiti/${project.scm.repository}</url>
   </ciManagement>
   <properties>
     <project.scm.repository>activiti-cloud-build</project.scm.repository>
@@ -175,15 +175,14 @@
     <!-- configuration properties for tests-->
     <generated-assertions-folder>${project.build.directory}/generated-test-sources/assertions</generated-assertions-folder>
     <generated-assertions-package>org.activiti.test</generated-assertions-package>
-    <!-- configurations for Spring REST docs -->
-    <asciidoc.filename>index.adoc</asciidoc.filename>
+
     <!-- plugin versions -->
     <apt-maven-plugin.version>1.1.3</apt-maven-plugin.version>
     <assertj-assertions-generator-maven-plugin.version>2.0.0</assertj-assertions-generator-maven-plugin.version>
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
     <docker-maven-plugin.version>0.32.0</docker-maven-plugin.version>
-    <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
@@ -423,7 +422,7 @@
         <configuration>
           <deployAtEnd>true</deployAtEnd>
         </configuration>
-      </plugin>      
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,132 @@
     </license>
   </licenses>
   <developers>
+    <developer>
+      <id>almerico</id>
+      <name>Oleksandr Merkulov</name>
+      <organization>IntroPro Ventures</organization>
+      <organizationUrl>http://introproventures.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>balsarori</id>
+      <name>Bassam Al-Sarori</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>daisuke-yoshimoto</id>
+      <name>Daisuke Yoshimoto</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>erdemedeiros</id>
+      <name>Elias De Medeiros</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>eromano</id>
+      <name>Eugenio Romano</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>ffazzini</id>
+      <name>Francesco Fazzini</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>igdianov</id>
+      <name>Igor Dianov</name>
+      <organization>IntroPro Ventures</organization>
+      <organizationUrl>http://introproventures.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>jesty</id>
+      <name>Davide Cerbo</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>magemello</id>
+      <name>Mario Romano</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>mauriziovitale</id>
+      <name>Maurizio Vitale</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>miguelruizdev</id>
+      <name>Miguel Ruiz</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>mmartinadanx</id>
+      <name>Miguel Ángel Martín</name>
+      <organization>Ixxus</organization>
+      <organizationUrl>http://www.ixxus.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>mteodori</id>
+      <name>Marcello Teodori</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>nazarethjim</id>
+      <name>Nazareth Jimenez Vela</name>
+      <organization>Ixxus</organization>
+      <organizationUrl>http://www.ixxus.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>pmartinezga</id>
+      <name>Pablo Martinez Garcia</name>
+      <organization>Ixxus</organization>
+      <organizationUrl>http://www.ixxus.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>popovicsandras</id>
+      <name>András Popovics</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>robfrank</id>
+      <name>Roberto Franchini</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>zoltanpalfi</id>
+      <name>Zoltan Palfi</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>CTI777</id>
+      <name>Illia Goncharov</name>
+      <organization>IntroPro Ventures</organization>
+      <organizationUrl>http://introproventures.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>EquinoxBlack</id>
+      <name>Rodion Savchuk</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>VitoAlbano</id>
+      <name>Vito Albano</name>
+      <organization>Alfresco</organization>
+      <organizationUrl>http://alfresco.com</organizationUrl>
+    </developer>
   </developers>
   <scm>
     <url>http://github.com/Activiti/${project.artifactId}</url>


### PR DESCRIPTION
This PR reverts changes for activiti-build parent and activiti-core-dependencies propagation into activiti-cloud-build parent pom

Part of https://github.com/Activiti/Activiti/issues/3099